### PR TITLE
remove symfony/framework-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
     "isotope/isotope-core": "*",
-    "symfony/framework-bundle": "^3.4",
     "heimrichhannot/contao-utils-bundle": "^2.0",
     "heimrichhannot/contao-fieldpalette-bundle": "~0.2||~1.0",
     "heimrichhannot/contao-frontendedit": "^6.0",


### PR DESCRIPTION
_Note:_ this change is untested.

As far as I can see, this bundle does not actually use any components of the `symfony/framework-bundle`, thus it should be removed as a dependency. Otherwise people will run into problems.